### PR TITLE
prevent hangup on empty line

### DIFF
--- a/src/vcf.js
+++ b/src/vcf.js
@@ -369,6 +369,7 @@ var VCF;
             var md, line = null, length = 0;
 
             for(;;) {
+                length = input.match(/^(.*)(?:\r?\n|$)/)[0].length;
                 if((md = input.match(this.lineRE))) {
                     // Unfold quoted-printables (vCard 2.1) into a single line before parsing.
                     // "Soft" linebreaks are indicated by a '=' at the end of the line, and do


### PR DESCRIPTION
When VCard contains an empty line (Android export Base64 Picture). the loop gets stuck.  
This fixed it.
